### PR TITLE
add navigation links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ Quill is a registration system designed especially for hackathons. For hackers, 
 
 ![Login Splash](./docs/images/screenshots/login.png)
 
+# Navigation
+
+- [Features](#features)
+- [Setup](#setup)
+- [Customizing For Your Event](#customizing-for-your-event)
+- [Contributing](#contributing)
+- [Feedback / Questions](#feedback--questions)
+- [License](#license)
+
 # Features
 ## Quill for Users
 ### Dashboard


### PR DESCRIPTION
I added navigation links near the top of the README.md in order to make it easier for people to get to the later parts of the file (i.e. the part that isn't a ton of huge images). We can add to these links whenever we add documentation for our parts of the project.